### PR TITLE
Implement Weekly Time Allocations

### DIFF
--- a/bruno-collections/TimeTracker-REST/allocations/copy-week.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/copy-week.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Copy Week Allocations
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/v1/allocations/copy
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "from_week": "2024-12-16",
+    "to_week": "2024-12-23"
+  }
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return copied allocations", () => {
+    expect(body).to.have.property('copied_count');
+    expect(body.allocations).to.be.an('array');
+    expect(body.copied_count).to.equal(body.allocations.length);
+  });
+  
+  test("Copied allocations should be for target week", () => {
+    body.allocations.forEach(allocation => {
+      expect(allocation.week_starting).to.equal("2024-12-23");
+    });
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/create-allocation.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/create-allocation.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Create Allocation
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/allocations
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "project_id": "{{projectId}}",
+    "week_starting": "{{mondayDate}}",
+    "hours": 20,
+    "notes": "Frontend development and design reviews"
+  }
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+  mondayDate: "2024-12-16" // Must be a Monday
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 201", () => {
+    expect(status).to.equal(201);
+  });
+  
+  test("Should return allocation data", () => {
+    expect(body).to.have.property('id');
+    expect(body.hours).to.equal(20);
+    expect(body.week_starting).to.equal("2024-12-16");
+  });
+  
+  test("Should include project details", () => {
+    expect(body.project).to.exist;
+    expect(body.project).to.have.property('name');
+    expect(body.project.client).to.have.property('name');
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/create-multiple.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/create-multiple.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Create Another Allocation
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/v1/allocations
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "project_id": "{{anotherProjectId}}",
+    "week_starting": "2024-12-16",
+    "hours": 15,
+    "notes": "Backend API development"
+  }
+}
+
+vars:pre-request {
+  anotherProjectId: // Set to a different project ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 201", () => {
+    expect(status).to.equal(201);
+  });
+  
+  test("Should create second allocation for same week", () => {
+    expect(body.week_starting).to.equal("2024-12-16");
+    expect(body.hours).to.equal(15);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/delete-allocation.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/delete-allocation.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Delete Allocation
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/allocations/:id
+  body: none
+  auth: basic
+}
+
+params:path {
+  id: {{allocationId}}
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  allocationId: // Set to valid allocation ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status } = res;
+  
+  test("Status should be 204", () => {
+    expect(status).to.equal(204);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/error-invalid-week.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/error-invalid-week.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Error - Invalid Week Start
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/v1/allocations
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "project_id": "{{projectId}}",
+    "week_starting": "2024-12-17", // Tuesday, not Monday
+    "hours": 10,
+    "notes": "This should fail"
+  }
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Should return 400 for non-Monday date", () => {
+    expect(status).to.equal(400);
+  });
+  
+  test("Error should mention Monday requirement", () => {
+    expect(body.error).to.include("Monday");
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/get-week-allocations.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/get-week-allocations.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Get Week Allocations
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/allocations/week?week={{weekDate}}
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  weekDate: "2024-12-16" // Any date in the week
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return week summary", () => {
+    expect(body).to.have.all.keys('week_starting', 'total_hours', 'allocations');
+    expect(body.total_hours).to.be.a('number');
+  });
+  
+  test("Total hours should match sum", () => {
+    const sum = body.allocations.reduce((acc, alloc) => acc + alloc.hours, 0);
+    expect(body.total_hours).to.equal(sum);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/helper-get-mondays.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/helper-get-mondays.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Helper - Get Monday Dates
+  type: http
+  seq: 0
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+tests {
+  const { expect } = require('chai');
+  
+  test("Calculate Monday dates for testing", () => {
+    const getMonday = (date) => {
+      const d = new Date(date);
+      const day = d.getDay();
+      const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+      d.setDate(diff);
+      return d.toISOString().split('T')[0];
+    };
+    
+    const today = new Date();
+    const thisMonday = getMonday(today);
+    const nextMonday = getMonday(new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000));
+    const lastMonday = getMonday(new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000));
+    
+    console.log('Monday Dates for Testing:');
+    console.log('Last Monday:', lastMonday);
+    console.log('This Monday:', thisMonday);
+    console.log('Next Monday:', nextMonday);
+    
+    // Always pass
+    expect(true).to.be.true;
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/list-allocations.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/list-allocations.bru
@@ -1,0 +1,38 @@
+meta {
+  name: List Allocations
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/allocations?limit=20&offset=0
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return allocation list", () => {
+    expect(body).to.have.all.keys('allocations', 'total', 'offset', 'limit');
+    expect(body.allocations).to.be.an('array');
+  });
+  
+  test("Each allocation should have project info", () => {
+    if (body.allocations.length > 0) {
+      const allocation = body.allocations[0];
+      expect(allocation.project).to.exist;
+      expect(allocation.project.client).to.exist;
+    }
+  });
+}

--- a/bruno-collections/TimeTracker-REST/allocations/update-allocation.bru
+++ b/bruno-collections/TimeTracker-REST/allocations/update-allocation.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Update Allocation
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/api/v1/allocations/:id
+  body: json
+  auth: basic
+}
+
+params:path {
+  id: {{allocationId}}
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "hours": 25,
+    "notes": "Increased hours for additional feature work"
+  }
+}
+
+vars:pre-request {
+  allocationId: // Set to valid allocation ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should update hours", () => {
+    expect(body.hours).to.equal(25);
+    expect(body.notes).to.include("additional feature");
+  });
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -10,6 +10,7 @@ func SetupRoutes(router *gin.Engine) {
 	authHandler := handlers.NewAuthHandler()
 	clientHandler := handlers.NewClientHandler()
 	projectHandler := handlers.NewProjectHandler()
+	allocationHandler := handlers.NewAllocationHandler()
 
 	api := router.Group("/api/v1")
 	{
@@ -39,6 +40,17 @@ func SetupRoutes(router *gin.Engine) {
 				projects.GET("/:id", projectHandler.GetProject)
 				projects.PUT("/:id", projectHandler.UpdateProject)
 				projects.DELETE("/:id", projectHandler.DeleteProject)
+			}
+
+			allocations := protected.Group("/allocations")
+			{
+				allocations.POST("", allocationHandler.CreateAllocation)
+				allocations.GET("", allocationHandler.ListAllocations)
+				allocations.GET("/week", allocationHandler.GetWeekAllocations)
+				allocations.GET("/:id", allocationHandler.GetAllocation)
+				allocations.PUT("/:id", allocationHandler.UpdateAllocation)
+				allocations.DELETE("/:id", allocationHandler.DeleteAllocation)
+				allocations.POST("/copy", allocationHandler.CopyWeekAllocations)
 			}
 		}
 	}

--- a/internal/handlers/allocations.go
+++ b/internal/handlers/allocations.go
@@ -1,0 +1,313 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/SteelyBretty/consultant-time-tracker/internal/middleware"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/models"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/schemas"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/services"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type AllocationHandler struct {
+	allocationService *services.AllocationService
+}
+
+func NewAllocationHandler() *AllocationHandler {
+	return &AllocationHandler{
+		allocationService: services.NewAllocationService(),
+	}
+}
+
+func (h *AllocationHandler) CreateAllocation(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	var req schemas.CreateAllocationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request format",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	weekStarting, _ := time.Parse("2006-01-02", req.WeekStarting)
+
+	allocation, err := h.allocationService.CreateAllocation(
+		userID, req.ProjectID, weekStarting, req.Hours, req.Notes,
+	)
+	if err != nil {
+		switch err {
+		case services.ErrInvalidWeekStart:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Week must start on Monday"})
+		case services.ErrAllocationExists:
+			c.JSON(http.StatusConflict, gin.H{"error": "Allocation already exists for this week"})
+		case services.ErrProjectNotActive:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Project is not active"})
+		default:
+			if err.Error() == "project not found or access denied" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create allocation"})
+			}
+		}
+		return
+	}
+
+	c.JSON(http.StatusCreated, h.mapAllocationToResponse(allocation))
+}
+
+func (h *AllocationHandler) GetAllocation(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	allocationID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid allocation ID"})
+		return
+	}
+
+	allocation, err := h.allocationService.GetAllocation(userID, allocationID)
+	if err != nil {
+		if err == services.ErrAllocationNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Allocation not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch allocation"})
+		return
+	}
+
+	c.JSON(http.StatusOK, h.mapAllocationToResponse(allocation))
+}
+
+func (h *AllocationHandler) ListAllocations(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+
+	var projectID *uuid.UUID
+	if projectIDStr := c.Query("project_id"); projectIDStr != "" {
+		if id, err := uuid.Parse(projectIDStr); err == nil {
+			projectID = &id
+		}
+	}
+
+	var startDate, endDate *time.Time
+	if startStr := c.Query("start_date"); startStr != "" {
+		if date, err := time.Parse("2006-01-02", startStr); err == nil {
+			startDate = &date
+		}
+	}
+	if endStr := c.Query("end_date"); endStr != "" {
+		if date, err := time.Parse("2006-01-02", endStr); err == nil {
+			endDate = &date
+		}
+	}
+
+	if limit > 100 {
+		limit = 100
+	}
+
+	allocations, total, err := h.allocationService.ListAllocations(userID, projectID, startDate, endDate, offset, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch allocations"})
+		return
+	}
+
+	response := schemas.AllocationListResponse{
+		Allocations: make([]schemas.AllocationResponse, len(allocations)),
+		Total:       total,
+		Offset:      offset,
+		Limit:       limit,
+	}
+
+	for i, allocation := range allocations {
+		response.Allocations[i] = *h.mapAllocationToResponse(allocation)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *AllocationHandler) GetWeekAllocations(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	weekStr := c.Query("week")
+	if weekStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Week parameter is required"})
+		return
+	}
+
+	week, err := time.Parse("2006-01-02", weekStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid week format, use YYYY-MM-DD"})
+		return
+	}
+
+	allocations, totalHours, err := h.allocationService.GetWeekAllocations(userID, week)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch week allocations"})
+		return
+	}
+
+	response := schemas.WeekAllocationResponse{
+		WeekStarting: week.Format("2006-01-02"),
+		TotalHours:   totalHours,
+		Allocations:  make([]schemas.AllocationResponse, len(allocations)),
+	}
+
+	for i, allocation := range allocations {
+		response.Allocations[i] = *h.mapAllocationToResponse(allocation)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *AllocationHandler) UpdateAllocation(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	allocationID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid allocation ID"})
+		return
+	}
+
+	var req schemas.UpdateAllocationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request format",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	allocation, err := h.allocationService.UpdateAllocation(userID, allocationID, req.Hours, req.Notes)
+	if err != nil {
+		if err == services.ErrAllocationNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Allocation not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update allocation"})
+		return
+	}
+
+	c.JSON(http.StatusOK, h.mapAllocationToResponse(allocation))
+}
+
+func (h *AllocationHandler) DeleteAllocation(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	allocationID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid allocation ID"})
+		return
+	}
+
+	if err := h.allocationService.DeleteAllocation(userID, allocationID); err != nil {
+		if err == services.ErrAllocationNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Allocation not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete allocation"})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+func (h *AllocationHandler) CopyWeekAllocations(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	var req schemas.CopyAllocationsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request format",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	fromWeek, _ := time.Parse("2006-01-02", req.FromWeek)
+	toWeek, _ := time.Parse("2006-01-02", req.ToWeek)
+
+	allocations, err := h.allocationService.CopyWeekAllocations(userID, fromWeek, toWeek)
+	if err != nil {
+		if err == services.ErrInvalidWeekStart {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Target week must start on Monday"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to copy allocations"})
+		return
+	}
+
+	response := schemas.CopyAllocationsResponse{
+		CopiedCount: len(allocations),
+		Allocations: make([]schemas.AllocationResponse, len(allocations)),
+	}
+
+	for i, allocation := range allocations {
+		response.Allocations[i] = *h.mapAllocationToResponse(allocation)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *AllocationHandler) mapAllocationToResponse(allocation *models.Allocation) *schemas.AllocationResponse {
+	response := &schemas.AllocationResponse{
+		ID:           allocation.ID,
+		ProjectID:    allocation.ProjectID,
+		WeekStarting: allocation.WeekStarting.Format("2006-01-02"),
+		Hours:        allocation.Hours,
+		Notes:        allocation.Notes,
+		CreatedAt:    allocation.CreatedAt,
+		UpdatedAt:    allocation.UpdatedAt,
+	}
+
+	if allocation.Project.ID != uuid.Nil {
+		response.Project = &schemas.ProjectSummary{
+			ID:           allocation.Project.ID,
+			Name:         allocation.Project.Name,
+			Code:         allocation.Project.Code,
+			BillableRate: allocation.Project.BillableRate,
+			Currency:     allocation.Project.Currency,
+			Client: schemas.ClientSummary{
+				ID:   allocation.Project.Client.ID,
+				Name: allocation.Project.Client.Name,
+				Code: allocation.Project.Client.Code,
+			},
+		}
+	}
+
+	return response
+}

--- a/internal/schemas/allocation.go
+++ b/internal/schemas/allocation.go
@@ -1,0 +1,68 @@
+package schemas
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateAllocationRequest struct {
+	ProjectID    uuid.UUID `json:"project_id" binding:"required"`
+	WeekStarting string    `json:"week_starting" binding:"required,datetime=2006-01-02"`
+	Hours        float64   `json:"hours" binding:"required,min=0,max=168"`
+	Notes        string    `json:"notes" binding:"max=500"`
+}
+
+type UpdateAllocationRequest struct {
+	Hours float64 `json:"hours" binding:"required,min=0,max=168"`
+	Notes string  `json:"notes" binding:"max=500"`
+}
+
+type CopyAllocationsRequest struct {
+	FromWeek string `json:"from_week" binding:"required,datetime=2006-01-02"`
+	ToWeek   string `json:"to_week" binding:"required,datetime=2006-01-02"`
+}
+
+type AllocationResponse struct {
+	ID           uuid.UUID       `json:"id"`
+	ProjectID    uuid.UUID       `json:"project_id"`
+	Project      *ProjectSummary `json:"project,omitempty"`
+	WeekStarting string          `json:"week_starting"`
+	Hours        float64         `json:"hours"`
+	Notes        string          `json:"notes"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+type ProjectSummary struct {
+	ID           uuid.UUID     `json:"id"`
+	Name         string        `json:"name"`
+	Code         string        `json:"code"`
+	Client       ClientSummary `json:"client"`
+	BillableRate float64       `json:"billable_rate"`
+	Currency     string        `json:"currency"`
+}
+
+type ClientSummary struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+	Code string    `json:"code"`
+}
+
+type AllocationListResponse struct {
+	Allocations []AllocationResponse `json:"allocations"`
+	Total       int64                `json:"total"`
+	Offset      int                  `json:"offset"`
+	Limit       int                  `json:"limit"`
+}
+
+type WeekAllocationResponse struct {
+	WeekStarting string               `json:"week_starting"`
+	TotalHours   float64              `json:"total_hours"`
+	Allocations  []AllocationResponse `json:"allocations"`
+}
+
+type CopyAllocationsResponse struct {
+	CopiedCount int                  `json:"copied_count"`
+	Allocations []AllocationResponse `json:"allocations"`
+}

--- a/internal/services/allocation_service.go
+++ b/internal/services/allocation_service.go
@@ -1,0 +1,216 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/SteelyBretty/consultant-time-tracker/internal/database"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type AllocationService struct{}
+
+func NewAllocationService() *AllocationService {
+	return &AllocationService{}
+}
+
+var (
+	ErrAllocationNotFound = errors.New("allocation not found")
+	ErrAllocationExists   = errors.New("allocation already exists for this week")
+	ErrInvalidWeekStart   = errors.New("week must start on Monday")
+	ErrProjectNotActive   = errors.New("project is not active")
+)
+
+func (s *AllocationService) getWeekStart(date time.Time) time.Time {
+	weekday := int(date.Weekday())
+	if weekday == 0 {
+		weekday = 7
+	}
+	return date.AddDate(0, 0, -(weekday - 1)).Truncate(24 * time.Hour)
+}
+
+func (s *AllocationService) CreateAllocation(userID, projectID uuid.UUID, weekStarting time.Time, hours float64, notes string) (*models.Allocation, error) {
+	weekStart := s.getWeekStart(weekStarting)
+	if !weekStart.Equal(weekStarting) {
+		return nil, ErrInvalidWeekStart
+	}
+
+	var project models.Project
+	if err := database.DB.Where("id = ? AND user_id = ?", projectID, userID).First(&project).Error; err != nil {
+		return nil, errors.New("project not found or access denied")
+	}
+
+	if !project.IsActive || project.Status != models.ProjectStatusActive {
+		return nil, ErrProjectNotActive
+	}
+
+	var existing models.Allocation
+	err := database.DB.Where("project_id = ? AND user_id = ? AND week_starting = ?",
+		projectID, userID, weekStart).First(&existing).Error
+	if err == nil {
+		return nil, ErrAllocationExists
+	}
+
+	allocation := &models.Allocation{
+		ProjectID:    projectID,
+		UserID:       userID,
+		WeekStarting: weekStart,
+		Hours:        hours,
+		Notes:        notes,
+	}
+
+	if err := database.DB.Create(allocation).Error; err != nil {
+		return nil, err
+	}
+
+	if err := database.DB.Preload("Project.Client").First(allocation, allocation.ID).Error; err != nil {
+		return nil, err
+	}
+
+	return allocation, nil
+}
+
+func (s *AllocationService) GetAllocation(userID, allocationID uuid.UUID) (*models.Allocation, error) {
+	var allocation models.Allocation
+	err := database.DB.Preload("Project.Client").Where("id = ? AND user_id = ?", allocationID, userID).First(&allocation).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAllocationNotFound
+		}
+		return nil, err
+	}
+	return &allocation, nil
+}
+
+func (s *AllocationService) ListAllocations(userID uuid.UUID, projectID *uuid.UUID, startDate, endDate *time.Time, offset, limit int) ([]*models.Allocation, int64, error) {
+	var allocations []*models.Allocation
+	var total int64
+
+	query := database.DB.Model(&models.Allocation{}).Preload("Project.Client").Where("user_id = ?", userID)
+
+	if projectID != nil {
+		query = query.Where("project_id = ?", *projectID)
+	}
+
+	if startDate != nil {
+		weekStart := s.getWeekStart(*startDate)
+		query = query.Where("week_starting >= ?", weekStart)
+	}
+
+	if endDate != nil {
+		weekEnd := s.getWeekStart(*endDate)
+		query = query.Where("week_starting <= ?", weekEnd)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := query.Offset(offset).Limit(limit).Order("week_starting DESC, created_at DESC").Find(&allocations).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return allocations, total, nil
+}
+
+func (s *AllocationService) GetWeekAllocations(userID uuid.UUID, weekStarting time.Time) ([]*models.Allocation, float64, error) {
+	weekStart := s.getWeekStart(weekStarting)
+
+	var allocations []*models.Allocation
+	err := database.DB.Preload("Project.Client").
+		Where("user_id = ? AND week_starting = ?", userID, weekStart).
+		Order("created_at ASC").
+		Find(&allocations).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var totalHours float64
+	for _, allocation := range allocations {
+		totalHours += allocation.Hours
+	}
+
+	return allocations, totalHours, nil
+}
+
+func (s *AllocationService) UpdateAllocation(userID, allocationID uuid.UUID, hours float64, notes string) (*models.Allocation, error) {
+	var allocation models.Allocation
+
+	if err := database.DB.Where("id = ? AND user_id = ?", allocationID, userID).First(&allocation).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAllocationNotFound
+		}
+		return nil, err
+	}
+
+	updates := map[string]interface{}{
+		"hours": hours,
+		"notes": notes,
+	}
+
+	if err := database.DB.Model(&allocation).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+
+	if err := database.DB.Preload("Project.Client").First(&allocation, allocation.ID).Error; err != nil {
+		return nil, err
+	}
+
+	return &allocation, nil
+}
+
+func (s *AllocationService) DeleteAllocation(userID, allocationID uuid.UUID) error {
+	result := database.DB.Where("id = ? AND user_id = ?", allocationID, userID).Delete(&models.Allocation{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrAllocationNotFound
+	}
+	return nil
+}
+
+func (s *AllocationService) CopyWeekAllocations(userID uuid.UUID, fromWeek, toWeek time.Time) ([]*models.Allocation, error) {
+	fromWeekStart := s.getWeekStart(fromWeek)
+	toWeekStart := s.getWeekStart(toWeek)
+
+	if !toWeekStart.Equal(toWeek) {
+		return nil, ErrInvalidWeekStart
+	}
+
+	var sourceAllocations []*models.Allocation
+	err := database.DB.Where("user_id = ? AND week_starting = ?", userID, fromWeekStart).Find(&sourceAllocations).Error
+	if err != nil {
+		return nil, err
+	}
+
+	var newAllocations []*models.Allocation
+	for _, source := range sourceAllocations {
+		var existing models.Allocation
+		err := database.DB.Where("project_id = ? AND user_id = ? AND week_starting = ?",
+			source.ProjectID, userID, toWeekStart).First(&existing).Error
+		if err == nil {
+			continue
+		}
+
+		newAllocation := &models.Allocation{
+			ProjectID:    source.ProjectID,
+			UserID:       userID,
+			WeekStarting: toWeekStart,
+			Hours:        source.Hours,
+			Notes:        "Copied from week of " + fromWeekStart.Format("2006-01-02"),
+		}
+
+		if err := database.DB.Create(newAllocation).Error; err == nil {
+			newAllocations = append(newAllocations, newAllocation)
+		}
+	}
+
+	for _, allocation := range newAllocations {
+		database.DB.Preload("Project.Client").First(allocation, allocation.ID)
+	}
+
+	return newAllocations, nil
+}


### PR DESCRIPTION
## Milestone 7: Weekly Time Allocations

Implements time allocation system for weekly planning.

### Features Implemented:
- ✅ Create allocations for projects by week
- ✅ List allocations with filtering by project/date
- ✅ Get weekly view with total hours
- ✅ Update allocation hours and notes  
- ✅ Copy entire week's allocations
- ✅ Delete allocations
- ✅ Monday-only week starts enforced

### API Endpoints:
- `POST /api/v1/allocations` - Create allocation
- `GET /api/v1/allocations` - List allocations
- `GET /api/v1/allocations/week` - Get week summary
- `GET /api/v1/allocations/:id` - Get single allocation
- `PUT /api/v1/allocations/:id` - Update allocation
- `DELETE /api/v1/allocations/:id` - Delete allocation
- `POST /api/v1/allocations/copy` - Copy week

### Business Rules:
- Week must start on Monday
- Cannot duplicate project allocation in same week
- Only active projects can have allocations
- Maximum 168 hours per allocation (full week)
- Copy function skips existing allocations

### Query Parameters:
- `project_id` - Filter by project
- `start_date` - Filter from date
- `end_date` - Filter to date
- `week` - Get specific week (any date in week)

### Testing:
- Complete Bruno test suite
- Helper to calculate Monday dates
- Error case testing
- Multi-project week scenarios