### PR TITLE
Implement Time Entry Tracking system

### DIFF
--- a/bruno-collections/TimeTracker-REST/time-entries/create-time-entry.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/create-time-entry.bru
@@ -1,0 +1,52 @@
+meta {
+  name: Create Time Entry
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/time-entries
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "project_id": "{{projectId}}",
+    "date": "{{today}}",
+    "hours": 8,
+    "description": "Implemented user authentication module",
+    "is_billable": true
+  }
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+  today: new Date().toISOString().split('T')[0]
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 201", () => {
+    expect(status).to.equal(201);
+  });
+  
+  test("Should return time entry data", () => {
+    expect(body).to.have.property('id');
+    expect(body.hours).to.equal(8);
+    expect(body.is_billable).to.be.true;
+  });
+  
+  test("Should include project details", () => {
+    expect(body.project).to.exist;
+    expect(body.project).to.have.property('name');
+    expect(body.project.client).to.have.property('name');
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/delete-time-entry.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/delete-time-entry.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Delete Time Entry
+  type: http
+  seq: 10
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/time-entries/:id
+  body: none
+  auth: basic
+}
+
+params:path {
+  id: {{timeEntryId}}
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  timeEntryId: // Set to valid time entry ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status } = res;
+  
+  test("Status should be 204", () => {
+    expect(status).to.equal(204);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/error-future-date.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/error-future-date.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Error - Future Date
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/api/v1/time-entries
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "project_id": "{{projectId}}",
+    "date": "{{futureDate}}",
+    "hours": 8,
+    "description": "This should fail",
+    "is_billable": true
+  }
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  futureDate: tomorrow.toISOString().split('T')[0]
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Should return 400 for future date", () => {
+    expect(status).to.equal(400);
+  });
+  
+  test("Error should mention future dates", () => {
+    expect(body.error).to.include("future");
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/filter-by-project.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/filter-by-project.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Filter by Project and Date Range
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries?project_id={{projectId}}&start_date={{startDate}}&end_date={{endDate}}&is_billable=true
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+  startDate: "2024-12-01"
+  endDate: "2024-12-31"
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("All entries should match filters", () => {
+    const projectId = req.url.match(/project_id=([^&]+)/)[1];
+    body.time_entries.forEach(entry => {
+      expect(entry.project_id).to.equal(projectId);
+      expect(entry.is_billable).to.be.true;
+      
+      const entryDate = new Date(entry.date);
+      expect(entryDate >= new Date("2024-12-01")).to.be.true;
+      expect(entryDate <= new Date("2024-12-31")).to.be.true;
+    });
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/get-day-entries.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/get-day-entries.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Get Day Entries
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries/day?date={{date}}
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  date: new Date().toISOString().split('T')[0]
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return day summary", () => {
+    expect(body).to.have.all.keys('date', 'total_hours', 'time_entries');
+    expect(body.total_hours).to.be.a('number');
+  });
+  
+  test("Total hours should match sum", () => {
+    const sum = body.time_entries.reduce((acc, entry) => acc + entry.hours, 0);
+    expect(body.total_hours).to.equal(sum);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/get-project-comparison.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/get-project-comparison.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Get Project Week Comparison
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries/projects/:projectId/week-comparison?week={{weekDate}}
+  body: none
+  auth: basic
+}
+
+params:path {
+  projectId: {{projectId}}
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  projectId: // Set to valid project ID
+  weekDate: "2024-12-16"
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return comparison data", () => {
+    expect(body).to.have.all.keys(
+      'project_id', 'week_starting', 'allocated_hours', 
+      'actual_hours', 'variance', 'variance_percent'
+    );
+  });
+  
+  test("Variance calculations should be correct", () => {
+    expect(body.variance).to.equal(body.actual_hours - body.allocated_hours);
+    if (body.allocated_hours > 0) {
+      const expectedPercent = (body.variance / body.allocated_hours) * 100;
+      expect(body.variance_percent).to.be.closeTo(expectedPercent, 0.01);
+    }
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/get-week-entries.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/get-week-entries.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Get Week Entries
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries/week?week={{weekDate}}
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  weekDate: "2024-12-16" // Any date in the week
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return week data", () => {
+    expect(body).to.have.all.keys('week_starting', 'time_entries', 'daily_totals', 'week_total');
+    expect(body.daily_totals).to.be.an('object');
+  });
+  
+  test("Week total should match daily totals sum", () => {
+    const sum = Object.values(body.daily_totals).reduce((acc, hours) => acc + hours, 0);
+    expect(body.week_total).to.be.closeTo(sum, 0.01);
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/get-week-summary.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/get-week-summary.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Get Week Summary
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries/week-summary?week={{weekDate}}
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+vars:pre-request {
+  weekDate: "2024-12-16"
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return allocation vs actual comparison", () => {
+    expect(body).to.have.all.keys('week_starting', 'projects', 'total_allocated', 'total_actual');
+    expect(body.projects).to.be.an('array');
+  });
+  
+  test("Each project should show variance", () => {
+    body.projects.forEach(project => {
+      expect(project).to.have.all.keys(
+        'project_id', 'project', 'allocated_hours', 'actual_hours', 'variance'
+      );
+      expect(project.variance).to.equal(project.actual_hours - project.allocated_hours);
+    });
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/list-time-entries.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/list-time-entries.bru
@@ -1,0 +1,38 @@
+meta {
+  name: List Time Entries
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/time-entries?limit=20&offset=0
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should return time entry list", () => {
+    expect(body).to.have.all.keys('time_entries', 'total', 'offset', 'limit');
+    expect(body.time_entries).to.be.an('array');
+  });
+  
+  test("Entries should be ordered by date desc", () => {
+    if (body.time_entries.length > 1) {
+      const dates = body.time_entries.map(e => new Date(e.date));
+      const sorted = [...dates].sort((a, b) => b - a);
+      expect(dates).to.deep.equal(sorted);
+    }
+  });
+}

--- a/bruno-collections/TimeTracker-REST/time-entries/update-time-entry.bru
+++ b/bruno-collections/TimeTracker-REST/time-entries/update-time-entry.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Update Time Entry
+  type: http
+  seq: 7
+}
+
+put {
+  url: {{baseUrl}}/api/v1/time-entries/:id
+  body: json
+  auth: basic
+}
+
+params:path {
+  id: {{timeEntryId}}
+}
+
+auth:basic {
+  username: johndoe
+  password: password123
+}
+
+body:json {
+  {
+    "hours": 7.5,
+    "description": "Implemented auth module and fixed bugs",
+    "is_billable": true
+  }
+}
+
+vars:pre-request {
+  timeEntryId: // Set to valid time entry ID
+}
+
+tests {
+  const { expect } = require('chai');
+  const { status, body } = res;
+  
+  test("Status should be 200", () => {
+    expect(status).to.equal(200);
+  });
+  
+  test("Should update time entry", () => {
+    expect(body.hours).to.equal(7.5);
+    expect(body.description).to.include("fixed bugs");
+  });
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -11,7 +11,7 @@ func SetupRoutes(router *gin.Engine) {
 	clientHandler := handlers.NewClientHandler()
 	projectHandler := handlers.NewProjectHandler()
 	allocationHandler := handlers.NewAllocationHandler()
-
+	timeEntryHandler := handlers.NewTimeEntryHandler()
 	api := router.Group("/api/v1")
 	{
 		auth := api.Group("/auth")
@@ -51,6 +51,19 @@ func SetupRoutes(router *gin.Engine) {
 				allocations.PUT("/:id", allocationHandler.UpdateAllocation)
 				allocations.DELETE("/:id", allocationHandler.DeleteAllocation)
 				allocations.POST("/copy", allocationHandler.CopyWeekAllocations)
+			}
+
+			timeEntries := protected.Group("/time-entries")
+			{
+				timeEntries.POST("", timeEntryHandler.CreateTimeEntry)
+				timeEntries.GET("", timeEntryHandler.ListTimeEntries)
+				timeEntries.GET("/day", timeEntryHandler.GetDayEntries)
+				timeEntries.GET("/week", timeEntryHandler.GetWeekEntries)
+				timeEntries.GET("/week-summary", timeEntryHandler.GetWeekSummary)
+				timeEntries.GET("/projects/:projectId/week-comparison", timeEntryHandler.GetProjectWeekComparison)
+				timeEntries.GET("/:id", timeEntryHandler.GetTimeEntry)
+				timeEntries.PUT("/:id", timeEntryHandler.UpdateTimeEntry)
+				timeEntries.DELETE("/:id", timeEntryHandler.DeleteTimeEntry)
 			}
 		}
 	}

--- a/internal/handlers/time_entries.go
+++ b/internal/handlers/time_entries.go
@@ -1,0 +1,435 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/SteelyBretty/consultant-time-tracker/internal/middleware"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/models"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/schemas"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/services"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type TimeEntryHandler struct {
+	timeEntryService *services.TimeEntryService
+	projectService   *services.ProjectService
+}
+
+func NewTimeEntryHandler() *TimeEntryHandler {
+	return &TimeEntryHandler{
+		timeEntryService: services.NewTimeEntryService(),
+		projectService:   services.NewProjectService(),
+	}
+}
+
+func (h *TimeEntryHandler) CreateTimeEntry(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	var req schemas.CreateTimeEntryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request format",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	date, _ := time.Parse("2006-01-02", req.Date)
+
+	timeEntry, err := h.timeEntryService.CreateTimeEntry(
+		userID, req.ProjectID, date, req.Hours, req.Description, req.IsBillable,
+	)
+	if err != nil {
+		switch err {
+		case services.ErrTimeEntryExists:
+			c.JSON(http.StatusConflict, gin.H{"error": "Time entry already exists for this date"})
+		case services.ErrDateInFuture:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot log time for future dates"})
+		default:
+			if err.Error() == "project not found or access denied" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create time entry"})
+			}
+		}
+		return
+	}
+
+	c.JSON(http.StatusCreated, h.mapTimeEntryToResponse(timeEntry))
+}
+
+func (h *TimeEntryHandler) GetTimeEntry(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	timeEntryID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid time entry ID"})
+		return
+	}
+
+	timeEntry, err := h.timeEntryService.GetTimeEntry(userID, timeEntryID)
+	if err != nil {
+		if err == services.ErrTimeEntryNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Time entry not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch time entry"})
+		return
+	}
+
+	c.JSON(http.StatusOK, h.mapTimeEntryToResponse(timeEntry))
+}
+
+func (h *TimeEntryHandler) ListTimeEntries(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+
+	var projectID *uuid.UUID
+	if projectIDStr := c.Query("project_id"); projectIDStr != "" {
+		if id, err := uuid.Parse(projectIDStr); err == nil {
+			projectID = &id
+		}
+	}
+
+	var startDate, endDate *time.Time
+	if startStr := c.Query("start_date"); startStr != "" {
+		if date, err := time.Parse("2006-01-02", startStr); err == nil {
+			startDate = &date
+		}
+	}
+	if endStr := c.Query("end_date"); endStr != "" {
+		if date, err := time.Parse("2006-01-02", endStr); err == nil {
+			endDate = &date
+		}
+	}
+
+	var isBillable *bool
+	if billableStr := c.Query("is_billable"); billableStr != "" {
+		billable := billableStr == "true"
+		isBillable = &billable
+	}
+
+	if limit > 100 {
+		limit = 100
+	}
+
+	timeEntries, total, err := h.timeEntryService.ListTimeEntries(userID, projectID, startDate, endDate, isBillable, offset, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch time entries"})
+		return
+	}
+
+	response := schemas.TimeEntryListResponse{
+		TimeEntries: make([]schemas.TimeEntryResponse, len(timeEntries)),
+		Total:       total,
+		Offset:      offset,
+		Limit:       limit,
+	}
+
+	for i, entry := range timeEntries {
+		response.TimeEntries[i] = *h.mapTimeEntryToResponse(entry)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *TimeEntryHandler) GetDayEntries(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	dateStr := c.Query("date")
+	if dateStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Date parameter is required"})
+		return
+	}
+
+	date, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid date format, use YYYY-MM-DD"})
+		return
+	}
+
+	entries, totalHours, err := h.timeEntryService.GetDayEntries(userID, date)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch day entries"})
+		return
+	}
+
+	response := schemas.DayEntriesResponse{
+		Date:        dateStr,
+		TotalHours:  totalHours,
+		TimeEntries: make([]schemas.TimeEntryResponse, len(entries)),
+	}
+
+	for i, entry := range entries {
+		response.TimeEntries[i] = *h.mapTimeEntryToResponse(entry)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *TimeEntryHandler) GetWeekEntries(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	weekStr := c.Query("week")
+	if weekStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Week parameter is required"})
+		return
+	}
+
+	week, err := time.Parse("2006-01-02", weekStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid week format, use YYYY-MM-DD"})
+		return
+	}
+
+	entries, dailyTotals, err := h.timeEntryService.GetWeekEntries(userID, week)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch week entries"})
+		return
+	}
+
+	weekTotal := float64(0)
+	for _, total := range dailyTotals {
+		weekTotal += total
+	}
+
+	response := schemas.WeekEntriesResponse{
+		WeekStarting: week.Format("2006-01-02"),
+		TimeEntries:  make([]schemas.TimeEntryResponse, len(entries)),
+		DailyTotals:  dailyTotals,
+		WeekTotal:    weekTotal,
+	}
+
+	for i, entry := range entries {
+		response.TimeEntries[i] = *h.mapTimeEntryToResponse(entry)
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *TimeEntryHandler) GetProjectWeekComparison(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+
+	weekStr := c.Query("week")
+	if weekStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Week parameter is required"})
+		return
+	}
+
+	week, err := time.Parse("2006-01-02", weekStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid week format"})
+		return
+	}
+
+	allocatedHours, actualHours, err := h.timeEntryService.GetProjectWeekComparison(userID, projectID, week)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get comparison"})
+		return
+	}
+
+	variance := actualHours - allocatedHours
+	variancePercent := float64(0)
+	if allocatedHours > 0 {
+		variancePercent = (variance / allocatedHours) * 100
+	}
+
+	response := schemas.ProjectWeekComparisonResponse{
+		ProjectID:       projectID,
+		WeekStarting:    week.Format("2006-01-02"),
+		AllocatedHours:  allocatedHours,
+		ActualHours:     actualHours,
+		Variance:        variance,
+		VariancePercent: variancePercent,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *TimeEntryHandler) GetWeekSummary(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	weekStr := c.Query("week")
+	if weekStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Week parameter is required"})
+		return
+	}
+
+	week, err := time.Parse("2006-01-02", weekStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid week format"})
+		return
+	}
+
+	summary, err := h.timeEntryService.GetWeekSummary(userID, week)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get week summary"})
+		return
+	}
+
+	response := schemas.WeekSummaryResponse{
+		WeekStarting: week.Format("2006-01-02"),
+		Projects:     []schemas.ProjectWeekSummary{},
+	}
+
+	for projectID, hours := range summary {
+		project, _ := h.projectService.GetProjectByID(userID, projectID)
+
+		projectSummary := schemas.ProjectWeekSummary{
+			ProjectID:      projectID,
+			AllocatedHours: hours["allocated"],
+			ActualHours:    hours["actual"],
+			Variance:       hours["actual"] - hours["allocated"],
+		}
+
+		if project != nil {
+			projectSummary.Project = &schemas.ProjectSummary{
+				ID:           project.ID,
+				Name:         project.Name,
+				Code:         project.Code,
+				BillableRate: project.BillableRate,
+				Currency:     project.Currency,
+				Client: schemas.ClientSummary{
+					ID:   project.Client.ID,
+					Name: project.Client.Name,
+					Code: project.Client.Code,
+				},
+			}
+		}
+
+		response.Projects = append(response.Projects, projectSummary)
+		response.TotalAllocated += hours["allocated"]
+		response.TotalActual += hours["actual"]
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *TimeEntryHandler) UpdateTimeEntry(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	timeEntryID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid time entry ID"})
+		return
+	}
+
+	var req schemas.UpdateTimeEntryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request format",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	timeEntry, err := h.timeEntryService.UpdateTimeEntry(userID, timeEntryID, req.Hours, req.Description, req.IsBillable)
+	if err != nil {
+		if err == services.ErrTimeEntryNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Time entry not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update time entry"})
+		return
+	}
+
+	c.JSON(http.StatusOK, h.mapTimeEntryToResponse(timeEntry))
+}
+
+func (h *TimeEntryHandler) DeleteTimeEntry(c *gin.Context) {
+	userID, err := middleware.GetUserID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	timeEntryID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid time entry ID"})
+		return
+	}
+
+	if err := h.timeEntryService.DeleteTimeEntry(userID, timeEntryID); err != nil {
+		if err == services.ErrTimeEntryNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Time entry not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete time entry"})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+func (h *TimeEntryHandler) mapTimeEntryToResponse(entry *models.TimeEntry) *schemas.TimeEntryResponse {
+	response := &schemas.TimeEntryResponse{
+		ID:          entry.ID,
+		ProjectID:   entry.ProjectID,
+		Date:        time.Time(entry.Date).Format("2006-01-02"),
+		Hours:       entry.Hours,
+		Description: entry.Description,
+		IsBillable:  entry.IsBillable,
+		CreatedAt:   entry.CreatedAt,
+		UpdatedAt:   entry.UpdatedAt,
+	}
+
+	if entry.Project.ID != uuid.Nil {
+		response.Project = &schemas.ProjectSummary{
+			ID:           entry.Project.ID,
+			Name:         entry.Project.Name,
+			Code:         entry.Project.Code,
+			BillableRate: entry.Project.BillableRate,
+			Currency:     entry.Project.Currency,
+			Client: schemas.ClientSummary{
+				ID:   entry.Project.Client.ID,
+				Name: entry.Project.Client.Name,
+				Code: entry.Project.Client.Code,
+			},
+		}
+	}
+
+	return response
+}

--- a/internal/schemas/time_entry.go
+++ b/internal/schemas/time_entry.go
@@ -1,0 +1,77 @@
+package schemas
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateTimeEntryRequest struct {
+	ProjectID   uuid.UUID `json:"project_id" binding:"required"`
+	Date        string    `json:"date" binding:"required,datetime=2006-01-02"`
+	Hours       float64   `json:"hours" binding:"required,min=0,max=24"`
+	Description string    `json:"description" binding:"required,min=1,max=1000"`
+	IsBillable  bool      `json:"is_billable"`
+}
+
+type UpdateTimeEntryRequest struct {
+	Hours       float64 `json:"hours" binding:"required,min=0,max=24"`
+	Description string  `json:"description" binding:"required,min=1,max=1000"`
+	IsBillable  bool    `json:"is_billable"`
+}
+
+type TimeEntryResponse struct {
+	ID          uuid.UUID       `json:"id"`
+	ProjectID   uuid.UUID       `json:"project_id"`
+	Project     *ProjectSummary `json:"project,omitempty"`
+	Date        string          `json:"date"`
+	Hours       float64         `json:"hours"`
+	Description string          `json:"description"`
+	IsBillable  bool            `json:"is_billable"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+type TimeEntryListResponse struct {
+	TimeEntries []TimeEntryResponse `json:"time_entries"`
+	Total       int64               `json:"total"`
+	Offset      int                 `json:"offset"`
+	Limit       int                 `json:"limit"`
+}
+
+type DayEntriesResponse struct {
+	Date        string              `json:"date"`
+	TotalHours  float64             `json:"total_hours"`
+	TimeEntries []TimeEntryResponse `json:"time_entries"`
+}
+
+type WeekEntriesResponse struct {
+	WeekStarting string              `json:"week_starting"`
+	TimeEntries  []TimeEntryResponse `json:"time_entries"`
+	DailyTotals  map[string]float64  `json:"daily_totals"`
+	WeekTotal    float64             `json:"week_total"`
+}
+
+type ProjectWeekComparisonResponse struct {
+	ProjectID       uuid.UUID `json:"project_id"`
+	WeekStarting    string    `json:"week_starting"`
+	AllocatedHours  float64   `json:"allocated_hours"`
+	ActualHours     float64   `json:"actual_hours"`
+	Variance        float64   `json:"variance"`
+	VariancePercent float64   `json:"variance_percent"`
+}
+
+type WeekSummaryResponse struct {
+	WeekStarting   string               `json:"week_starting"`
+	Projects       []ProjectWeekSummary `json:"projects"`
+	TotalAllocated float64              `json:"total_allocated"`
+	TotalActual    float64              `json:"total_actual"`
+}
+
+type ProjectWeekSummary struct {
+	ProjectID      uuid.UUID       `json:"project_id"`
+	Project        *ProjectSummary `json:"project"`
+	AllocatedHours float64         `json:"allocated_hours"`
+	ActualHours    float64         `json:"actual_hours"`
+	Variance       float64         `json:"variance"`
+}

--- a/internal/services/time_entry_service.go
+++ b/internal/services/time_entry_service.go
@@ -1,0 +1,256 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/SteelyBretty/consultant-time-tracker/internal/database"
+	"github.com/SteelyBretty/consultant-time-tracker/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+type TimeEntryService struct{}
+
+func NewTimeEntryService() *TimeEntryService {
+	return &TimeEntryService{}
+}
+
+var (
+	ErrTimeEntryNotFound = errors.New("time entry not found")
+	ErrTimeEntryExists   = errors.New("time entry already exists for this date")
+	ErrExceedsAllocation = errors.New("time entry exceeds weekly allocation")
+	ErrNoAllocation      = errors.New("no allocation found for this week")
+	ErrDateInFuture      = errors.New("cannot log time for future dates")
+)
+
+func (s *TimeEntryService) getWeekStart(date time.Time) time.Time {
+	weekday := int(date.Weekday())
+	if weekday == 0 {
+		weekday = 7
+	}
+	return date.AddDate(0, 0, -(weekday - 1)).Truncate(24 * time.Hour)
+}
+
+func (s *TimeEntryService) CreateTimeEntry(userID, projectID uuid.UUID, date time.Time, hours float64, description string, isBillable bool) (*models.TimeEntry, error) {
+	if date.After(time.Now()) {
+		return nil, ErrDateInFuture
+	}
+
+	var project models.Project
+	if err := database.DB.Where("id = ? AND user_id = ?", projectID, userID).First(&project).Error; err != nil {
+		return nil, errors.New("project not found or access denied")
+	}
+
+	var existing models.TimeEntry
+	err := database.DB.Where("project_id = ? AND user_id = ? AND date = ?",
+		projectID, userID, datatypes.Date(date)).First(&existing).Error
+	if err == nil {
+		return nil, ErrTimeEntryExists
+	}
+
+	timeEntry := &models.TimeEntry{
+		ProjectID:   projectID,
+		UserID:      userID,
+		Date:        datatypes.Date(date),
+		Hours:       hours,
+		Description: description,
+		IsBillable:  isBillable,
+	}
+
+	if err := database.DB.Create(timeEntry).Error; err != nil {
+		return nil, err
+	}
+
+	if err := database.DB.Preload("Project.Client").First(timeEntry, timeEntry.ID).Error; err != nil {
+		return nil, err
+	}
+
+	return timeEntry, nil
+}
+
+func (s *TimeEntryService) GetTimeEntry(userID, timeEntryID uuid.UUID) (*models.TimeEntry, error) {
+	var timeEntry models.TimeEntry
+	err := database.DB.Preload("Project.Client").Where("id = ? AND user_id = ?", timeEntryID, userID).First(&timeEntry).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrTimeEntryNotFound
+		}
+		return nil, err
+	}
+	return &timeEntry, nil
+}
+
+func (s *TimeEntryService) ListTimeEntries(userID uuid.UUID, projectID *uuid.UUID, startDate, endDate *time.Time, isBillable *bool, offset, limit int) ([]*models.TimeEntry, int64, error) {
+	var timeEntries []*models.TimeEntry
+	var total int64
+
+	query := database.DB.Model(&models.TimeEntry{}).Preload("Project.Client").Where("user_id = ?", userID)
+
+	if projectID != nil {
+		query = query.Where("project_id = ?", *projectID)
+	}
+
+	if startDate != nil {
+		query = query.Where("date >= ?", datatypes.Date(*startDate))
+	}
+
+	if endDate != nil {
+		query = query.Where("date <= ?", datatypes.Date(*endDate))
+	}
+
+	if isBillable != nil {
+		query = query.Where("is_billable = ?", *isBillable)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := query.Offset(offset).Limit(limit).Order("date DESC, created_at DESC").Find(&timeEntries).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return timeEntries, total, nil
+}
+
+func (s *TimeEntryService) GetDayEntries(userID uuid.UUID, date time.Time) ([]*models.TimeEntry, float64, error) {
+	var entries []*models.TimeEntry
+	err := database.DB.Preload("Project.Client").
+		Where("user_id = ? AND date = ?", userID, datatypes.Date(date)).
+		Order("created_at ASC").
+		Find(&entries).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var totalHours float64
+	for _, entry := range entries {
+		totalHours += entry.Hours
+	}
+
+	return entries, totalHours, nil
+}
+
+func (s *TimeEntryService) GetWeekEntries(userID uuid.UUID, weekStarting time.Time) ([]*models.TimeEntry, map[string]float64, error) {
+	weekStart := s.getWeekStart(weekStarting)
+	weekEnd := weekStart.AddDate(0, 0, 6)
+
+	var entries []*models.TimeEntry
+	err := database.DB.Preload("Project.Client").
+		Where("user_id = ? AND date >= ? AND date <= ?", userID, datatypes.Date(weekStart), datatypes.Date(weekEnd)).
+		Order("date ASC, created_at ASC").
+		Find(&entries).Error
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dailyTotals := make(map[string]float64)
+	for _, entry := range entries {
+		dateStr := time.Time(entry.Date).Format("2006-01-02")
+		dailyTotals[dateStr] += entry.Hours
+	}
+
+	return entries, dailyTotals, nil
+}
+
+func (s *TimeEntryService) UpdateTimeEntry(userID, timeEntryID uuid.UUID, hours float64, description string, isBillable bool) (*models.TimeEntry, error) {
+	var timeEntry models.TimeEntry
+
+	if err := database.DB.Where("id = ? AND user_id = ?", timeEntryID, userID).First(&timeEntry).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrTimeEntryNotFound
+		}
+		return nil, err
+	}
+
+	updates := map[string]interface{}{
+		"hours":       hours,
+		"description": description,
+		"is_billable": isBillable,
+	}
+
+	if err := database.DB.Model(&timeEntry).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+
+	if err := database.DB.Preload("Project.Client").First(&timeEntry, timeEntry.ID).Error; err != nil {
+		return nil, err
+	}
+
+	return &timeEntry, nil
+}
+
+func (s *TimeEntryService) DeleteTimeEntry(userID, timeEntryID uuid.UUID) error {
+	result := database.DB.Where("id = ? AND user_id = ?", timeEntryID, userID).Delete(&models.TimeEntry{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrTimeEntryNotFound
+	}
+	return nil
+}
+
+func (s *TimeEntryService) GetProjectWeekComparison(userID, projectID uuid.UUID, weekStarting time.Time) (float64, float64, error) {
+	weekStart := s.getWeekStart(weekStarting)
+	weekEnd := weekStart.AddDate(0, 0, 6)
+
+	var allocation models.Allocation
+	err := database.DB.Where("project_id = ? AND user_id = ? AND week_starting = ?",
+		projectID, userID, weekStart).First(&allocation).Error
+
+	allocatedHours := float64(0)
+	if err == nil {
+		allocatedHours = allocation.Hours
+	}
+
+	var actualHours float64
+	err = database.DB.Model(&models.TimeEntry{}).
+		Where("project_id = ? AND user_id = ? AND date >= ? AND date <= ?",
+			projectID, userID, datatypes.Date(weekStart), datatypes.Date(weekEnd)).
+		Select("COALESCE(SUM(hours), 0)").
+		Scan(&actualHours).Error
+
+	return allocatedHours, actualHours, err
+}
+
+func (s *TimeEntryService) GetWeekSummary(userID uuid.UUID, weekStarting time.Time) (map[uuid.UUID]map[string]float64, error) {
+	weekStart := s.getWeekStart(weekStarting)
+	weekEnd := weekStart.AddDate(0, 0, 6)
+
+	type ProjectWeekData struct {
+		ProjectID      uuid.UUID
+		AllocatedHours float64
+		ActualHours    float64
+	}
+
+	var allocations []models.Allocation
+	database.DB.Where("user_id = ? AND week_starting = ?", userID, weekStart).Find(&allocations)
+
+	summary := make(map[uuid.UUID]map[string]float64)
+
+	for _, alloc := range allocations {
+		summary[alloc.ProjectID] = map[string]float64{
+			"allocated": alloc.Hours,
+			"actual":    0,
+		}
+	}
+
+	var entries []models.TimeEntry
+	database.DB.Where("user_id = ? AND date >= ? AND date <= ?",
+		userID, datatypes.Date(weekStart), datatypes.Date(weekEnd)).Find(&entries)
+
+	for _, entry := range entries {
+		if _, exists := summary[entry.ProjectID]; !exists {
+			summary[entry.ProjectID] = map[string]float64{
+				"allocated": 0,
+				"actual":    0,
+			}
+		}
+		summary[entry.ProjectID]["actual"] += entry.Hours
+	}
+
+	return summary, nil
+}


### PR DESCRIPTION
## Milestone 8: Time Entry Tracking

Implements daily time tracking with allocation comparison.

### Features Implemented:
- ✅ Create time entries for specific dates
- ✅ List entries with filtering options
- ✅ Day view with total hours
- ✅ Week view with daily breakdown
- ✅ Week summary comparing allocated vs actual
- ✅ Project-specific variance analysis
- ✅ Update and delete time entries
- ✅ Billable/non-billable tracking

### API Endpoints:
- `POST /api/v1/time-entries` - Create time entry
- `GET /api/v1/time-entries` - List entries
- `GET /api/v1/time-entries/day` - Get day summary
- `GET /api/v1/time-entries/week` - Get week entries
- `GET /api/v1/time-entries/week-summary` - Allocation vs actual
- `GET /api/v1/time-entries/projects/:id/week-comparison` - Project variance
- `GET /api/v1/time-entries/:id` - Get single entry
- `PUT /api/v1/time-entries/:id` - Update entry
- `DELETE /api/v1/time-entries/:id` - Delete entry

### Business Rules:
- Cannot log time for future dates
- One entry per project per day
- Maximum 24 hours per entry
- Tracks billable status for invoicing
- Shows variance from allocations

### Query Parameters:
- `project_id` - Filter by project
- `start_date/end_date` - Date range
- `is_billable` - Billable status
- `date` - Specific day
- `week` - Any date in target week

### Testing:
- Complete Bruno test suite
- Variance calculation tests
- Error handling for edge cases
- Date validation tests